### PR TITLE
Fix code execution error

### DIFF
--- a/Frontendcloud.py
+++ b/Frontendcloud.py
@@ -83,7 +83,7 @@ class APIConfig:
     telegram_bot_token: str = "8530766126:AAHs1ZoLwrwvT7JuPyn_9ymNVyddPtUXi-g"
     telegram_chat_id: str = "-1003278011521"
     telegram_enabled: bool = True
-    telegram_min_probability: float = 65.0
+    telegram_min_probability: float = 50.0
     
     def __post_init__(self):
         """Carica da variabili d'ambiente (override se presenti)"""


### PR DESCRIPTION
Adds a configurable minimum probability threshold for Telegram notifications.

This allows users to filter Telegram notifications to only include markets with a model probability above a specified threshold, improving the relevance of alerts.

---
<a href="https://cursor.com/background-agent?bcId=bc-053096d2-62dc-4caa-99cd-0b1215cf04c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-053096d2-62dc-4caa-99cd-0b1215cf04c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Telegram probability threshold (env-configurable and UI slider) to filter value bets and display their probabilities; skips sending if none pass.
> 
> - **Telegram**:
>   - **Config**: Introduces `api_config.telegram_min_probability` (env override via `TELEGRAM_MIN_PROBABILITY`) and exports `TELEGRAM_MIN_PROBABILITY`.
>   - **UI**: Adds Streamlit slider to set min probability threshold and persists it in `st.session_state`.
>   - **Messaging/Send Logic**:
>     - Value bets now include model probability in messages.
>     - Filters value bets below the threshold; if none pass, notification is not sent and an info message is shown.
>     - Minor refactor around error handling/flow for Telegram send.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1abac04cfb7bab49557e4be096a57aec088c187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->