### PR TITLE
Fix: Correggi NameError su variabili xg/xa non definite

### DIFF
--- a/Frontendcloud.py
+++ b/Frontendcloud.py
@@ -12891,13 +12891,13 @@ if st.button("🎯 CALCOLA MODELLO AVANZATO", type="primary"):
                 total_apertura=total_apertura if total_apertura != 2.5 else None,
                 spread_corrente=spread_corrente if spread_corrente != 0.0 else None,
                 xg_for_home=xg_home_for if (xg_home_for and isinstance(xg_home_for, (int, float)) and xg_home_for > 0) else None,
-                xg_against_home=xg_home_against if (xg_home_against and isinstance(xg_home_against, (int, float)) and xg_home_against > 0) else None,
+                xg_against_home=xg_against_home if (xg_against_home and isinstance(xg_against_home, (int, float)) and xg_against_home > 0) else None,
                 xg_for_away=xg_away_for if (xg_away_for and isinstance(xg_away_for, (int, float)) and xg_away_for > 0) else None,
-                xg_against_away=xg_away_against if (xg_away_against and isinstance(xg_away_against, (int, float)) and xg_away_against > 0) else None,
+                xg_against_away=xg_against_away if (xg_against_away and isinstance(xg_against_away, (int, float)) and xg_against_away > 0) else None,
                 xa_for_home=xa_home_for if (xa_home_for and isinstance(xa_home_for, (int, float)) and xa_home_for > 0) else None,
-                xa_against_home=xa_home_against if (xa_home_against and isinstance(xa_home_against, (int, float)) and xa_home_against > 0) else None,
+                xa_against_home=xa_against_home if (xa_against_home and isinstance(xa_against_home, (int, float)) and xa_against_home > 0) else None,
                 xa_for_away=xa_away_for if (xa_away_for and isinstance(xa_away_for, (int, float)) and xa_away_for > 0) else None,
-                xa_against_away=xa_away_against if (xa_away_against and isinstance(xa_away_against, (int, float)) and xa_away_against > 0) else None,
+                xa_against_away=xa_against_away if (xa_against_away and isinstance(xa_against_away, (int, float)) and xa_against_away > 0) else None,
             )
             
             validated = validation_result["validated"]
@@ -13026,17 +13026,17 @@ if st.button("🎯 CALCOLA MODELLO AVANZATO", type="primary"):
         if has_xg:
             xg_args = {
                 "xg_for_home": xg_home_for,
-                "xg_against_home": xg_home_against,
+                "xg_against_home": xg_against_home,
                 "xg_for_away": xg_away_for,
-                "xg_against_away": xg_away_against,
+                "xg_against_away": xg_against_away,
             }
         xa_args = {}
         if has_xa:
             xa_args = {
                 "xa_for_home": xa_home_for if xa_home_for > 0 else None,
-                "xa_against_home": xa_home_against if xa_home_against > 0 else None,
+                "xa_against_home": xa_against_home if xa_against_home > 0 else None,
                 "xa_for_away": xa_away_for if xa_away_for > 0 else None,
-                "xa_against_away": xa_away_against if xa_away_against > 0 else None,
+                "xa_against_away": xa_against_away if xa_against_away > 0 else None,
             }
         
         ris = risultato_completo_improved(


### PR DESCRIPTION
Problema:
- NameError: xg_home_against non definito (riga 12894)
- Dopo la semplificazione interfaccia, i nomi delle variabili erano inconsistenti (xg_home_against vs xg_against_home)

Correzioni:
- Riga 12894: xg_home_against → xg_against_home
- Riga 12896: xg_away_against → xg_against_away
- Riga 12898: xa_home_against → xa_against_home
- Riga 12900: xa_away_against → xa_against_away
- Righe 13029-13039: stesse correzioni nel secondo blocco

Verifica:
- Sintassi Python corretta
- Nessuna occorrenza variabili vecchie rimanente
- Nomi variabili ora consistenti in tutto il file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes xg/xa "against" variable names and updates all references to avoid NameError in validation and model args.
> 
> - **Core (Frontendcloud.py)**:
>   - Align variable names: `xg_home_against`→`xg_against_home`, `xg_away_against`→`xg_against_away`, `xa_home_against`→`xa_against_home`, `xa_away_against`→`xa_against_away`.
>   - Update usages in validation payload and model argument dicts (`xg_args`, `xa_args`) to the new names to ensure consistency and prevent `NameError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ac944d051aa546874df9a8e22c814e7c478858. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->