### PR TITLE
fix: Missing 'total' key in cache stats fallback returns

### DIFF
--- a/api_manager.py
+++ b/api_manager.py
@@ -211,7 +211,7 @@ class CacheManager:
             conn.close()
 
             if not result:
-                return {"hits": 0, "misses": 0, "hit_rate": 0.0}
+                return {"hits": 0, "misses": 0, "total": 0, "hit_rate": 0.0}
 
             hits, misses = result
             total = hits + misses
@@ -226,7 +226,7 @@ class CacheManager:
 
         except Exception as e:
             logger.error(f"❌ Error getting cache stats: {e}")
-            return {"hits": 0, "misses": 0, "hit_rate": 0.0}
+            return {"hits": 0, "misses": 0, "total": 0, "hit_rate": 0.0}
 
     def cleanup_old(self, days: int = 7):
         """Remove cache entries older than N days"""


### PR DESCRIPTION
## Bug Description:
When cache statistics are not available (first run or error), get_stats() returned incomplete dict missing 'total' key, causing KeyError: 'total' in Frontendcloud.py:15162 when accessing api_status['cache']['total'] in automatic mode.

## Root Cause:
- api_manager.py:214 - No data case: missing "total": 0
- api_manager.py:229 - Exception case: missing "total": 0

Normal case (line 220-225) correctly includes all keys.

## Fix:
Added "total": 0 to both fallback return statements to match the complete return structure.

## Impact:
- Fixes "Errore lettura API status: 'total'" in automatic mode
- Ensures consistent dict structure across all code paths
- No side effects - only adds missing key to edge cases

Tested: Empty cache and error scenarios now return complete dict.