### PR TITLE
Fix NameError in neural network module import

### DIFF
--- a/ai_system/blocco_1_calibrator.py
+++ b/ai_system/blocco_1_calibrator.py
@@ -40,40 +40,47 @@ from .config import AIConfig
 logger = logging.getLogger(__name__)
 
 
-class CalibratorMLP(nn.Module):
-    """
-    Multi-Layer Perceptron per calibrazione probabilità.
+# Define classes only if PyTorch is available
+if TORCH_AVAILABLE:
+    class CalibratorMLP(nn.Module):
+        """
+        Multi-Layer Perceptron per calibrazione probabilità.
 
-    Architecture:
-    Input → Hidden Layers → Dropout → Output (sigmoid)
-    """
+        Architecture:
+        Input → Hidden Layers → Dropout → Output (sigmoid)
+        """
 
-    def __init__(
-        self,
-        input_size: int,
-        hidden_layers: List[int],
-        dropout: float = 0.2
-    ):
-        super().__init__()
+        def __init__(
+            self,
+            input_size: int,
+            hidden_layers: List[int],
+            dropout: float = 0.2
+        ):
+            super().__init__()
 
-        layers = []
-        prev_size = input_size
+            layers = []
+            prev_size = input_size
 
-        # Hidden layers
-        for hidden_size in hidden_layers:
-            layers.append(nn.Linear(prev_size, hidden_size))
-            layers.append(nn.ReLU())
-            layers.append(nn.Dropout(dropout))
-            prev_size = hidden_size
+            # Hidden layers
+            for hidden_size in hidden_layers:
+                layers.append(nn.Linear(prev_size, hidden_size))
+                layers.append(nn.ReLU())
+                layers.append(nn.Dropout(dropout))
+                prev_size = hidden_size
 
-        # Output layer (sigmoid for probability)
-        layers.append(nn.Linear(prev_size, 1))
-        layers.append(nn.Sigmoid())
+            # Output layer (sigmoid for probability)
+            layers.append(nn.Linear(prev_size, 1))
+            layers.append(nn.Sigmoid())
 
-        self.network = nn.Sequential(*layers)
+            self.network = nn.Sequential(*layers)
 
-    def forward(self, x):
-        return self.network(x)
+        def forward(self, x):
+            return self.network(x)
+else:
+    # Dummy class when PyTorch is not available
+    class CalibratorMLP:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("PyTorch is required for CalibratorMLP. Install with: pip install torch")
 
 
 class ProbabilityCalibrator:

--- a/ai_system/blocco_6_odds_tracker.py
+++ b/ai_system/blocco_6_odds_tracker.py
@@ -32,18 +32,25 @@ from .config import AIConfig
 logger = logging.getLogger(__name__)
 
 
-class OddsLSTM(nn.Module):
-    """LSTM per previsione movimento quote"""
+# Define classes only if PyTorch is available
+if TORCH_AVAILABLE:
+    class OddsLSTM(nn.Module):
+        """LSTM per previsione movimento quote"""
 
-    def __init__(self, input_size: int, hidden_size: int, num_layers: int):
-        super().__init__()
-        self.lstm = nn.LSTM(input_size, hidden_size, num_layers, batch_first=True)
-        self.fc = nn.Linear(hidden_size, 1)  # Predict single odds value
+        def __init__(self, input_size: int, hidden_size: int, num_layers: int):
+            super().__init__()
+            self.lstm = nn.LSTM(input_size, hidden_size, num_layers, batch_first=True)
+            self.fc = nn.Linear(hidden_size, 1)  # Predict single odds value
 
-    def forward(self, x):
-        lstm_out, _ = self.lstm(x)
-        predictions = self.fc(lstm_out[:, -1, :])  # Last timestep
-        return predictions
+        def forward(self, x):
+            lstm_out, _ = self.lstm(x)
+            predictions = self.fc(lstm_out[:, -1, :])  # Last timestep
+            return predictions
+else:
+    # Dummy class when PyTorch is not available
+    class OddsLSTM:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("PyTorch is required for OddsLSTM. Install with: pip install torch")
 
 
 class OddsMovementTracker:


### PR DESCRIPTION
Fixes NameError when PyTorch is not available by:
- Wrapping CalibratorMLP class in TORCH_AVAILABLE check
- Wrapping OddsLSTM class in TORCH_AVAILABLE check
- Adding dummy classes with helpful error messages when PyTorch is unavailable
- This prevents module-level NameErrors during import when torch is not installed

Resolves import error in Frontendcloud.py at line 137.