### PR TITLE
fix: Handle None values in odds_history to prevent TypeError

### DIFF
--- a/Frontendcloud.py
+++ b/Frontendcloud.py
@@ -16443,7 +16443,7 @@ if st.button("🎯 ANALIZZA PARTITA", type="primary"):
                         bankroll=ai_bankroll_value,
                         config=ai_config,
                         # Additional context
-                        odds_history=odds_history if odds_history else None,
+                        odds_history=odds_history,  # Pass list directly (even if empty)
                         time_to_kickoff_hours=time_to_kickoff_hours,
                         match_date=match_datetime_combined
                     )

--- a/ai_system/blocco_2_confidence.py
+++ b/ai_system/blocco_2_confidence.py
@@ -109,7 +109,7 @@ class ConfidenceScorer:
 
         # 3. Odds stability features
         odds_current = additional_context.get("odds_current", 2.0)
-        odds_history = additional_context.get("odds_history", [])
+        odds_history = additional_context.get("odds_history") or []
 
         if len(odds_history) >= 3:
             # Calculate volatility
@@ -281,7 +281,7 @@ class ConfidenceScorer:
         score += data_quality * weights["data_completeness"]
 
         # 3. Odds stability (20%)
-        odds_history = additional_context.get("odds_history", [])
+        odds_history = additional_context.get("odds_history") or []
         if len(odds_history) >= 3:
             odds_values = [o["odds"] for o in odds_history]
             odds_std = np.std(odds_values)
@@ -358,7 +358,7 @@ class ConfidenceScorer:
             strength_factors.append(f"High data quality ({data_quality:.0%})")
 
         # Check odds stability
-        odds_history = additional_context.get("odds_history", [])
+        odds_history = additional_context.get("odds_history") or []
         if len(odds_history) >= 3:
             odds_values = [o["odds"] for o in odds_history]
             odds_std = np.std(odds_values)

--- a/ai_system/blocco_3_value_detector.py
+++ b/ai_system/blocco_3_value_detector.py
@@ -95,7 +95,7 @@ class ValueDetector:
         features.append(prob_odds_gap)
 
         # 4. Odds movement features
-        odds_history = odds_data.get("odds_history", [])
+        odds_history = odds_data.get("odds_history") or []
         if len(odds_history) >= 3:
             odds_values = [o["odds"] for o in odds_history]
             odds_first = odds_values[0]
@@ -275,8 +275,8 @@ class ValueDetector:
 
     def _detect_sharp_money(self, odds_data: Dict) -> bool:
         """Rileva sharp money movement"""
-        odds_history = odds_data.get("odds_history", [])
-        volume_history = odds_data.get("volume_history", [])
+        odds_history = odds_data.get("odds_history") or []
+        volume_history = odds_data.get("volume_history") or []
 
         if len(odds_history) < 3:
             return False

--- a/ai_system/blocco_6_odds_tracker.py
+++ b/ai_system/blocco_6_odds_tracker.py
@@ -84,6 +84,10 @@ class OddsMovementTracker:
             - sharp_money_detected: bool
             - reasoning: Spiegazione
         """
+        # Ensure odds_history is never None
+        if odds_history is None:
+            odds_history = []
+
         # Se decisione è SKIP, non serve monitoring
         if decision.get("decision") == "SKIP":
             return {

--- a/ai_system/pipeline.py
+++ b/ai_system/pipeline.py
@@ -504,7 +504,7 @@ def quick_analyze(
 
     odds_data = {
         "odds_current": odds,
-        "odds_history": kwargs.get("odds_history", []),
+        "odds_history": kwargs.get("odds_history") or [],  # Ensure never None
         "market": kwargs.get("market", "1x2"),
         "time_to_kickoff_hours": kwargs.get("time_to_kickoff", 24.0)
     }


### PR DESCRIPTION
Fixed "object of type 'NoneType' has no len()" error by:

1. Frontendcloud.py (line 16446): Changed to pass empty list [] instead of None when odds_history is empty
2. ai_system/pipeline.py (line 507): Added `or []` to ensure odds_history is never None
3. ai_system/blocco_2_confidence.py: Protected all odds_history.get() calls with `or []`
4. ai_system/blocco_3_value_detector.py: Protected all odds_history.get() calls with `or []`
5. ai_system/blocco_6_odds_tracker.py: Added None check at start of monitor() function

The issue occurred when empty lists were converted to None, then len() was called on None. All AI system components now safely handle empty or None odds_history values.