### PR TITLE
feat: Re-enable Telegram notifications for manual match analysis

### DIFF
--- a/Frontendcloud.py
+++ b/Frontendcloud.py
@@ -16847,6 +16847,48 @@ if st.button("🎯 ANALIZZA PARTITA", type="primary"):
 
         st.success(f"✅ Analisi completata per {match_name}")
 
+        # ============================================================
+        #   TELEGRAM NOTIFICATION (if enabled)
+        # ============================================================
+        if TELEGRAM_ENABLED and TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID:
+            # Verifica se almeno una probabilità supera la soglia minima
+            max_prob = max(ris['p_home'], ris['p_draw'], ris['p_away']) * 100
+
+            if max_prob >= TELEGRAM_MIN_PROBABILITY:
+                try:
+                    # Formatta messaggio con tutti i mercati
+                    telegram_message = format_analysis_for_telegram(
+                        match_name=match_name,
+                        ris=ris,
+                        odds_1=validated['odds_1'],
+                        odds_x=validated['odds_x'],
+                        odds_2=validated['odds_2'],
+                        quality_score=validated['quality_score'],
+                        market_conf=validated['market_confidence'],
+                        value_bets=None  # Opzionale: lista value bets
+                    )
+
+                    # Invia notifica
+                    telegram_result = send_telegram_message(
+                        message=telegram_message,
+                        bot_token=TELEGRAM_BOT_TOKEN,
+                        chat_id=TELEGRAM_CHAT_ID,
+                        parse_mode="HTML"
+                    )
+
+                    if telegram_result.get('success'):
+                        st.info(f"📱 Notifica Telegram inviata con successo!")
+                        logger.info(f"📱 Telegram notification sent for {match_name}")
+                    else:
+                        st.warning(f"⚠️ Errore invio Telegram: {telegram_result.get('error_message', 'Unknown')}")
+                        logger.warning(f"⚠️ Telegram error: {telegram_result.get('error_message')}")
+
+                except Exception as e:
+                    st.warning(f"⚠️ Errore notifica Telegram: {str(e)}")
+                    logger.error(f"❌ Telegram notification error: {e}")
+            else:
+                logger.info(f"ℹ️  Telegram notification skipped: max probability {max_prob:.1f}% < {TELEGRAM_MIN_PROBABILITY}%")
+
         # === VISUALIZZAZIONE RISULTATI ===
         st.markdown("---")
         st.subheader(f"📊 Risultati Analisi: {match_name}")


### PR DESCRIPTION
Restored automatic Telegram notifications when analyzing matches manually.

What it does:
- After each match analysis, automatically sends notification to Telegram
- Includes all markets (1X2, Over/Under, BTTS, Asian Handicap, HT/FT, etc.)
- Shows probabilities for all calculated markets
- Only sends if max probability >= configured threshold

Configuration:
- TELEGRAM_ENABLED = True (in Frontendcloud.py or ai_system/config.py)
- TELEGRAM_BOT_TOKEN = "your_bot_token"
- TELEGRAM_CHAT_ID = "your_chat_id"
- TELEGRAM_MIN_PROBABILITY = 50.0 (minimum probability % to send)

Features:
- Formatted message with HTML (bold, italic)
- All markets included (Over/Under, BTTS, Asian Handicap, HT/FT)
- Quality score and market confidence
- Model parameters (lambda home/away, rho)
- Clean Sheet probabilities
- Even/Odd markets
- Combined HT+FT markets

Message format:
⚽ ANALISI COMPLETATA
🏆 Match Name
📊 Quality Score + Market Confidence
🎯 1X2 Probabilities
⚽ Over/Under (FT + HT)
🎲 Even/Odd
🛡️ Clean Sheet
🎯 Asian Handicap
🔗 Combined HT+FT

Integration point: Line 16850-16890 in Frontendcloud.py
Function used: format_analysis_for_telegram() (line 12634)

User can:
- Enable/disable with TELEGRAM_ENABLED flag
- Set minimum probability threshold
- Receive notifications immediately after analysis
- See all markets in one message