### PR TITLE
Troubleshoot fly.io launch manifest error

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-app = "asianodds"
+app = "software-asianodds"
 primary_region = "ams"
 
 [build]


### PR DESCRIPTION
Update `app` name in `fly.toml` to match the deployed application name.

The previous `app` name in `fly.toml` was `asianodds`, while the actual deployed application name was `software-asianodds`. This change ensures consistency and simplifies future deployments by removing the need to explicitly pass the `-a` flag.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f256b74-fe98-4132-84c2-a2923e45d9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f256b74-fe98-4132-84c2-a2923e45d9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

