### PR TITLE
Deploy application to Fly.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Copy requirements first to leverage Docker layer caching
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Copy lean requirements for Fly.io deployment first to leverage Docker layer caching
+COPY requirements-fly.txt .
+RUN pip install --no-cache-dir -r requirements-fly.txt
 
 # Copy application code
 COPY . .

--- a/requirements-fly.txt
+++ b/requirements-fly.txt
@@ -1,0 +1,16 @@
+pandas>=1.5.0
+numpy>=1.23.0
+scipy>=1.9.0
+streamlit>=1.28.0
+requests>=2.28.0
+scikit-learn>=1.2.0
+matplotlib>=3.6.0
+seaborn>=0.12.0
+openpyxl>=3.1.0
+python-dotenv>=0.21.0
+python-dateutil>=2.8.2
+numba>=0.56.0
+beautifulsoup4>=4.11.0
+plotly>=5.13.0
+feedparser>=6.0.10
+joblib>=1.2.0


### PR DESCRIPTION
Refactor Dockerfile to use a lean `requirements-fly.txt` to reduce image size for Fly.io deployment.

This change resolves the "Not enough space to unpack image" error encountered during Fly.io deployment by ensuring the Docker image remains under the 8GB uncompressed limit.

---
<a href="https://cursor.com/background-agent?bcId=bc-932517dd-7fdf-4a48-a79b-b3289ac407de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-932517dd-7fdf-4a48-a79b-b3289ac407de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

