### PR TITLE
Remove live notifications

### DIFF
--- a/ai_system/background_services.py
+++ b/ai_system/background_services.py
@@ -127,7 +127,8 @@ class BackgroundAutomationService:
                 chat_id=chat_id,
                 min_ev=self._config.telegram_min_ev,
                 min_confidence=self._config.telegram_min_confidence,
-                rate_limit_seconds=self._config.telegram_rate_limit_seconds
+                rate_limit_seconds=self._config.telegram_rate_limit_seconds,
+                live_alerts_enabled=self._config.telegram_live_alerts_enabled
             )
         except Exception as exc:
             logger.warning("⚠️  Telegram notifier non disponibile: %s", exc)

--- a/ai_system/config.py
+++ b/ai_system/config.py
@@ -56,6 +56,7 @@ class AIConfig:
     telegram_min_ev: float = 5.0           # Min EV% per inviare notifica
     telegram_min_confidence: float = 60.0  # Min confidence per inviare
     telegram_rate_limit_seconds: int = 3   # Secondi tra messaggi
+    telegram_live_alerts_enabled: bool = False  # Disattiva notifiche live di default
 
     # Live monitoring settings
     live_monitoring_enabled: bool = False  # Enable auto-monitoring

--- a/ai_system/telegram_notifier.py
+++ b/ai_system/telegram_notifier.py
@@ -43,13 +43,15 @@ class TelegramNotifier:
         chat_id: str,
         min_ev: float = 5.0,
         min_confidence: float = 60.0,
-        rate_limit_seconds: int = 3
+        rate_limit_seconds: int = 3,
+        live_alerts_enabled: bool = True
     ):
         self.bot_token = bot_token
         self.chat_id = chat_id
         self.min_ev = min_ev
         self.min_confidence = min_confidence
         self.rate_limit_seconds = rate_limit_seconds
+        self.live_alerts_enabled = live_alerts_enabled
 
         self.last_message_time = 0
         self.messages_sent = 0
@@ -114,6 +116,10 @@ class TelegramNotifier:
         Returns:
             True se inviato
         """
+        if not self.live_alerts_enabled:
+            logger.debug("Live alerts disabilitati, skip invio per %s", match_data.get('match_id', 'unknown_match'))
+            return False
+
         self._apply_rate_limit()
 
         message = self._format_live_alert(match_data, live_result, alert_type)


### PR DESCRIPTION
Disable live Telegram notifications by default.

Adds a `telegram_live_alerts_enabled` flag to the configuration, set to `False` by default, to allow users to exclusively disable live notifications while keeping other notification types active.

---
<a href="https://cursor.com/background-agent?bcId=bc-214a3332-60a6-4a9f-a326-e1798bcfcdf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-214a3332-60a6-4a9f-a326-e1798bcfcdf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

